### PR TITLE
Cleaned stdout output

### DIFF
--- a/src/impulse.c
+++ b/src/impulse.c
@@ -64,7 +64,8 @@ static void get_source_info_callback( pa_context *c, const pa_source_info *i, in
 	if ( is_last || device != NULL )
 		swept_through = 1;
 
-	printf("%d -> %s\n",i->index, i->name);
+    // This could be the target of a toggleable option : show usable outputs.
+	// printf("%d -> %s\n",i->index, i->name);
 
 	assert(i);
 

--- a/src/impulse.c
+++ b/src/impulse.c
@@ -204,7 +204,6 @@ double *im_getSnapshot( int fft ) {
 
 void im_setup(int source) {
 	stream_index = source;
-	printf("Setup: %d\n", source);
 }
 
 void im_start ( void ) {

--- a/src/module.c
+++ b/src/module.c
@@ -59,7 +59,6 @@ static PyObject * impulse_setup( PyObject *self, PyObject *args, PyObject *kwarg
 	static char *kwlist[] = {"source", NULL};
 
 	PyArg_ParseTupleAndKeywords( args, kwargs, "i", kwlist, &source );
-	printf("Read : %d\n", source);
 	im_setup(source);
 
 	return Py_BuildValue("");


### PR DESCRIPTION
Smallish stdout cleaning.

The device listing could be used as an option, like "--show-devices" to list them instead of running.
