### PR TITLE
Fix bars with negative height

### DIFF
--- a/spectrumyzer.py
+++ b/spectrumyzer.py
@@ -326,6 +326,8 @@ class MainApp:
 		dx = self.config["left_offset"]
 		for i, height in enumerate(self.previous_sample_height):
 			width = self.bars.width + int(i < self.bars.mark)
+			if height < 0:
+				height = 0
 			cr.rectangle(dx, self.bars.win_height, width, - height)
 			dx += width + self.bars.padding
 		cr.fill()


### PR DESCRIPTION
Sometimes the bars overshoot a little bit while going down. This messes with my desktop decoration and is in my opinion not intended. I don't really know the reason why the overshoot happens (neither do I care) but this simple change should fix it.

Here you can find two pictures for comparision:
[https://imgur.com/a/RyMFi](https://imgur.com/a/RyMFi)